### PR TITLE
feat: Protocol handler

### DIFF
--- a/src/torrents/AddTorrentDialog.tsx
+++ b/src/torrents/AddTorrentDialog.tsx
@@ -17,6 +17,8 @@ function AddTorrentDialog() {
   const isAddDialogVisible = useSelector(
     (state) => state.torrents.isAddDialogVisible,
   )
+  const params = new URLSearchParams(window.location.search)
+  const magnetUrlFromParams = params.get('magnetUrl')
   const inputRef = useRef<HTMLInputElement>()
   const [magnetUrl, setMagnetUrl] = useState('')
   const [current, updateCurrent] = useState<
@@ -57,6 +59,13 @@ function AddTorrentDialog() {
   }, [isAddDialogVisible])
 
   useEffect(() => {
+    if (magnetUrlFromParams) {
+      setMagnetUrl(magnetUrlFromParams)
+      dispatch(actions.toggleAddDialog())
+    }
+  }, [dispatch, magnetUrlFromParams])
+
+  useEffect(() => {
     if (navigator.registerProtocolHandler) {
       const currentUrl = new URL(window.location.toString())
       currentUrl.search = ''
@@ -90,6 +99,7 @@ function AddTorrentDialog() {
         <form onSubmit={handleSubmit}>
           <TextField
             inputRef={inputRef}
+            value={magnetUrl}
             fullWidth={true}
             label="Magnet"
             onChange={(event) => {

--- a/src/torrents/AddTorrentDialog.tsx
+++ b/src/torrents/AddTorrentDialog.tsx
@@ -56,6 +56,18 @@ function AddTorrentDialog() {
     }
   }, [isAddDialogVisible])
 
+  useEffect(() => {
+    if (navigator.registerProtocolHandler) {
+      const currentUrl = new URL(window.location.toString())
+      currentUrl.search = ''
+      navigator.registerProtocolHandler(
+        'magnet',
+        `${currentUrl}?magnetUrl=%s`,
+        'Transmission',
+      )
+    }
+  }, [])
+
   return (
     <Dialog
       maxWidth="xs"

--- a/src/torrents/AddTorrentDialog.tsx
+++ b/src/torrents/AddTorrentDialog.tsx
@@ -61,13 +61,14 @@ function AddTorrentDialog() {
   useEffect(() => {
     if (magnetUrlFromParams) {
       setMagnetUrl(magnetUrlFromParams)
-      dispatch(actions.toggleAddDialog())
+      dispatch(actions.showAddDialog())
     }
   }, [dispatch, magnetUrlFromParams])
 
   useEffect(() => {
     if (navigator.registerProtocolHandler) {
       const currentUrl = new URL(window.location.toString())
+      // Remove any query params.
       currentUrl.search = ''
       navigator.registerProtocolHandler(
         'magnet',

--- a/src/torrents/actions.ts
+++ b/src/torrents/actions.ts
@@ -10,6 +10,8 @@ export const toggleTorrentChecked = createAction<{
   ids: number[]
 }>(constants.toggleTorrentChecked)
 export const toggleAddDialog = createAction(constants.toggleAddDialog)
+export const showAddDialog = createAction(constants.showAddDialog)
+export const hideAddDialog = createAction(constants.hideAddDialog)
 export const toggleDeleteDialog = createAction(constants.toggleDeleteDialog)
 
 export const addFields = createAction<Set<keyof TransmissionTorrent>>(
@@ -55,7 +57,7 @@ export const get = createAction(
 )
 
 export const torrentSetLocation = createAction(
-  'torrentSet',
+  constants.torrentSetLocation,
   (payload: { ids: TransmissionIdLookup; location: string }) => {
     return apiInstance.callServer('torrent-set-location', {
       ids: payload.ids,

--- a/src/torrents/constants.ts
+++ b/src/torrents/constants.ts
@@ -5,6 +5,8 @@ export default applyNamespace('torrents', {
   toggleTorrentChecked: 0,
 
   toggleAddDialog: 0,
+  showAddDialog: 0,
+  hideAddDialog: 0,
   toggleDeleteDialog: 0,
 
   addFields: 0,
@@ -20,4 +22,6 @@ export default applyNamespace('torrents', {
   removeTorrent: 0,
 
   getCustomSettings: 0,
+
+  torrentSetLocation: 0,
 })

--- a/src/torrents/reducer.ts
+++ b/src/torrents/reducer.ts
@@ -24,9 +24,9 @@ const initialState: State = {
 
 function normalizeTorrent(torrent: TransmissionTorrent): TransmissionTorrent {
   return {
-    trackerStats: [],
-    peers: [],
     ...torrent,
+    trackerStats: torrent.trackerStats || [],
+    peers: torrent.peers || [],
     files: (torrent.files || []).sort((a, b) => a.name.localeCompare(b.name)),
   }
 }
@@ -123,6 +123,20 @@ export default createReducer(initialState, {
     return {
       ...state,
       isAddDialogVisible: !state.isAddDialogVisible,
+    }
+  },
+
+  [constants.showAddDialog]: (state) => {
+    return {
+      ...state,
+      isAddDialogVisible: true,
+    }
+  },
+
+  [constants.hideAddDialog]: (state) => {
+    return {
+      ...state,
+      isAddDialogVisible: false,
     }
   },
 


### PR DESCRIPTION
Registers a protocol handler for `magnet://`. In support of that, adds support for a `?magnetUrl` query parameter.