### PR TITLE
feat: `xxs` breakpoint

### DIFF
--- a/src/inspector/Inspector.tsx
+++ b/src/inspector/Inspector.tsx
@@ -32,7 +32,7 @@ function Inspector() {
       anchor="right"
       PaperProps={{
         sx: (theme) => ({
-          [theme.breakpoints.only('xs')]: {
+          [theme.breakpoints.down('sm')]: {
             width: '100%',
             borderWidth: 0,
           },

--- a/src/mui/theme.ts
+++ b/src/mui/theme.ts
@@ -3,9 +3,28 @@ import { createTheme } from '@mui/material/styles'
 
 import SlideUp from '@src/lib/SlideUp'
 
+declare module '@mui/material/styles' {
+  interface BreakpointOverrides {
+    xxs: true
+  }
+}
+
 const ROUNDED_BORDER_RADIUS = 9999
 
 const theme = createTheme({
+  breakpoints: {
+    values: {
+      // What we actually care about
+      xxs: 0,
+      // "If you change the default breakpoints's values, you need to provide
+      // them all"
+      xs: 300,
+      sm: 600,
+      md: 900,
+      lg: 1200,
+      xl: 1536,
+    },
+  },
   palette: {
     primary: {
       main: '#6e6f91',

--- a/src/mui/theme.ts
+++ b/src/mui/theme.ts
@@ -134,6 +134,20 @@ const theme = createTheme({
         },
       },
     },
+    MuiSnackbar: {
+      styleOverrides: {
+        root: {
+          pointerEvents: 'none',
+        },
+      },
+    },
+    MuiAlert: {
+      styleOverrides: {
+        root: {
+          pointerEvents: 'initial',
+        },
+      },
+    },
   },
 })
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@mui/material'
 import Toolbar from '@mui/material/Toolbar'
 import Head from 'next/head'
 import { useEffect } from 'react'
@@ -42,7 +43,10 @@ export default function Home() {
         <MobileNavigationSpacer>
           <Toolbar variant="dense" />
         </MobileNavigationSpacer>
-        <BottomAppBar />
+
+        <Box display={['none', 'block']}>
+          <BottomAppBar />
+        </Box>
 
         <StatusNotifier />
       </TorrentDropZone>

--- a/src/torrents/TorrentListItem.tsx
+++ b/src/torrents/TorrentListItem.tsx
@@ -7,12 +7,14 @@ import {
   ListItemSecondaryAction,
   Stack,
   Typography,
+  useMediaQuery,
 } from '@mui/material'
 import Checkbox from '@mui/material/Checkbox'
 import LinearProgress, {
   LinearProgressProps,
 } from '@mui/material/LinearProgress'
 import ListItemText from '@mui/material/ListItemText'
+import { useTheme } from '@mui/material/styles'
 import { memo } from 'react'
 
 import { TorrentStatus } from '@src/api'
@@ -52,6 +54,14 @@ function TorrentListItem(props: Props) {
       />
     ) : null
 
+  // CSS-in-JS smell: We just want to not render the secondary action on xxs
+  // screens.
+  // Seems pretty easy! But we need the element to not exist in JSX, hiding it
+  // with CSS isn't enough.
+  // So, runtime costs for things browsers already do for us.
+  const theme = useTheme()
+  const isXxs = useMediaQuery(theme.breakpoints.only('xxs'))
+
   return (
     <ListItem
       button
@@ -62,7 +72,7 @@ function TorrentListItem(props: Props) {
       // TODO this is supposed to be read from the list context.
       dense
     >
-      <ListItemIcon>
+      <ListItemIcon sx={{ display: ['none', 'block'] }}>
         <Checkbox
           onClickCapture={(event) =>
             props.onCheckboxChange(event, props.torrent)
@@ -87,8 +97,8 @@ function TorrentListItem(props: Props) {
         }
       />
 
-      {props.secondaryAction ? (
-        <ListItemSecondaryAction>
+      {props.secondaryAction && !isXxs ? (
+        <ListItemSecondaryAction sx={{ display: ['none', 'block'] }}>
           {props.secondaryAction}
         </ListItemSecondaryAction>
       ) : undefined}

--- a/src/transmissionSettings/SettingsDialog.tsx
+++ b/src/transmissionSettings/SettingsDialog.tsx
@@ -59,7 +59,7 @@ const SettingsDialog = () => {
   }
 
   const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.only('xs'))
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const isVisible = useRootSelector(
     (state) => state.transmissionSettings.isSettingsDialogVisible,
   )


### PR DESCRIPTION
I bought a smart watch, and this absolutely works on there, but as you can image with MUI on such a small screen, it's cramped as heck.

This adds an xxs breakpoint and hides some things accordingly.