### PR TITLE
fix: Revert "feat: `xxs` breakpoint"

### DIFF
--- a/src/inspector/Inspector.tsx
+++ b/src/inspector/Inspector.tsx
@@ -32,7 +32,7 @@ function Inspector() {
       anchor="right"
       PaperProps={{
         sx: (theme) => ({
-          [theme.breakpoints.down('sm')]: {
+          [theme.breakpoints.only('xs')]: {
             width: '100%',
             borderWidth: 0,
           },

--- a/src/mui/theme.ts
+++ b/src/mui/theme.ts
@@ -3,28 +3,9 @@ import { createTheme } from '@mui/material/styles'
 
 import SlideUp from '@src/lib/SlideUp'
 
-declare module '@mui/material/styles' {
-  interface BreakpointOverrides {
-    xxs: true
-  }
-}
-
 const ROUNDED_BORDER_RADIUS = 9999
 
 const theme = createTheme({
-  breakpoints: {
-    values: {
-      // What we actually care about
-      xxs: 0,
-      // "If you change the default breakpoints's values, you need to provide
-      // them all"
-      xs: 300,
-      sm: 600,
-      md: 900,
-      lg: 1200,
-      xl: 1536,
-    },
-  },
   palette: {
     primary: {
       main: '#6e6f91',
@@ -131,20 +112,6 @@ const theme = createTheme({
         },
         bar: {
           borderRadius: ROUNDED_BORDER_RADIUS,
-        },
-      },
-    },
-    MuiSnackbar: {
-      styleOverrides: {
-        root: {
-          pointerEvents: 'none',
-        },
-      },
-    },
-    MuiAlert: {
-      styleOverrides: {
-        root: {
-          pointerEvents: 'initial',
         },
       },
     },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material'
 import Toolbar from '@mui/material/Toolbar'
 import Head from 'next/head'
 import { useEffect } from 'react'
@@ -43,10 +42,7 @@ export default function Home() {
         <MobileNavigationSpacer>
           <Toolbar variant="dense" />
         </MobileNavigationSpacer>
-
-        <Box display={['none', 'block']}>
-          <BottomAppBar />
-        </Box>
+        <BottomAppBar />
 
         <StatusNotifier />
       </TorrentDropZone>

--- a/src/torrents/TorrentListItem.tsx
+++ b/src/torrents/TorrentListItem.tsx
@@ -7,14 +7,12 @@ import {
   ListItemSecondaryAction,
   Stack,
   Typography,
-  useMediaQuery,
 } from '@mui/material'
 import Checkbox from '@mui/material/Checkbox'
 import LinearProgress, {
   LinearProgressProps,
 } from '@mui/material/LinearProgress'
 import ListItemText from '@mui/material/ListItemText'
-import { useTheme } from '@mui/material/styles'
 import { memo } from 'react'
 
 import { TorrentStatus } from '@src/api'
@@ -54,14 +52,6 @@ function TorrentListItem(props: Props) {
       />
     ) : null
 
-  // CSS-in-JS smell: We just want to not render the secondary action on xxs
-  // screens.
-  // Seems pretty easy! But we need the element to not exist in JSX, hiding it
-  // with CSS isn't enough.
-  // So, runtime costs for things browsers already do for us.
-  const theme = useTheme()
-  const isXxs = useMediaQuery(theme.breakpoints.only('xxs'))
-
   return (
     <ListItem
       button
@@ -72,7 +62,7 @@ function TorrentListItem(props: Props) {
       // TODO this is supposed to be read from the list context.
       dense
     >
-      <ListItemIcon sx={{ display: ['none', 'block'] }}>
+      <ListItemIcon>
         <Checkbox
           onClickCapture={(event) =>
             props.onCheckboxChange(event, props.torrent)
@@ -97,8 +87,8 @@ function TorrentListItem(props: Props) {
         }
       />
 
-      {props.secondaryAction && !isXxs ? (
-        <ListItemSecondaryAction sx={{ display: ['none', 'block'] }}>
+      {props.secondaryAction ? (
+        <ListItemSecondaryAction>
           {props.secondaryAction}
         </ListItemSecondaryAction>
       ) : undefined}

--- a/src/transmissionSettings/SettingsDialog.tsx
+++ b/src/transmissionSettings/SettingsDialog.tsx
@@ -59,7 +59,7 @@ const SettingsDialog = () => {
   }
 
   const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
+  const isMobile = useMediaQuery(theme.breakpoints.only('xs'))
   const isVisible = useRootSelector(
     (state) => state.transmissionSettings.isSettingsDialogVisible,
   )


### PR DESCRIPTION
Reverts mikew/transmission-material-ui#51

This needs a little more time in the oven:

- The breakpoint doesn't actually match Apple Watch 🤦 
- There's another `meta` tag for watches that might help, might make things incredibly cramped
- There's a few uses of "mui array-based responsive values", and since this new xxs breakpoint was added to the beginning of the list, they're not working as expected